### PR TITLE
Add alt-text to road map

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ Butter is still in development, I have a [plan](./doc/plan.md) to make this poss
 
 ## Road map
 
-[![Road map](./roadmap.png "click for more details")](https://github.com/neverRare/butter/projects/1)
+[![A road map for the Butter programming language, depicted in the form style a retro video game map. A single road snakes from right-to-left, with multiple stops, ending with a causeway leading to a castle in the middle of a lake. A flag is placed on the first stop. The project mascot (a cute yellow bear) is arriving at the second stop. The stops on the road are: parser, Hindley-Milner with row polymorphism and IR, lifetime analysis, refinement types, and finally LLVM. An enormous dragon looms behind the castle.](./roadmap.png "Road map")](https://github.com/neverRare/butter/projects/1)


### PR DESCRIPTION
In the interests of accessibility I added some alt-text to the roadmap!

An alternative to listing the roadmap items in the alt-text could be to restate the roadmap items in a checklist below.